### PR TITLE
Basic responsive images setup for spaces. Lowered default GD JPEG qua…

### DIFF
--- a/drupal/sync/core.entity_view_display.node.space.full.yml
+++ b/drupal/sync/core.entity_view_display.node.space.full.yml
@@ -15,6 +15,8 @@ dependencies:
     - field.field.node.space.field_equipment_information
     - field.field.node.space.field_floor
     - field.field.node.space.field_images
+    - field.field.node.space.field_inactivate_in_optime
+    - field.field.node.space.field_inactivated_in_drupal
     - field.field.node.space.field_last_changed_in_optime
     - field.field.node.space.field_legacy_url
     - field.field.node.space.field_optime_comments
@@ -23,14 +25,15 @@ dependencies:
     - field.field.node.space.field_price_category
     - field.field.node.space.field_reservation_link
     - field.field.node.space.field_room_type
-    - image.style.large
+    - field.field.node.space.field_street_address
     - node.type.space
+    - responsive_image.styles.space_image
   module:
     - ds
     - ds_chains
     - field_group
-    - image
     - link
+    - responsive_image
     - text
     - user
 third_party_settings:
@@ -56,9 +59,9 @@ third_party_settings:
       header:
         - group_header_main
         - group_hj
-        - node_title
         - field_reservation_link
         - field_images
+        - node_title
         - 'dynamic_token_field:node-referenced_address'
       right:
         - 'dynamic_copy_field:node-referenced_address_clone'
@@ -290,16 +293,16 @@ content:
       link_to_entity: false
     third_party_settings: {  }
   field_images:
-    type: image
+    type: responsive_image
     weight: 2
     region: header
     label: hidden
     settings:
-      image_style: large
-      image_link: file
+      responsive_image_style: space_image
+      image_link: content
     third_party_settings:
       ds:
-        ds_limit: ''
+        ds_limit: '2'
   field_price_category:
     type: entity_reference_entity_view
     weight: 9
@@ -326,6 +329,8 @@ hidden:
   field_building_id: true
   field_campus: true
   field_equipment: true
+  field_inactivate_in_optime: true
+  field_inactivated_in_drupal: true
   field_last_changed_in_optime: true
   field_legacy_url: true
   field_optime_comments: true
@@ -333,5 +338,6 @@ hidden:
   field_optime_index: true
   field_room_type: true
   field_smart_equipment_information: true
+  field_street_address: true
   langcode: true
   links: true

--- a/drupal/sync/core.extension.yml
+++ b/drupal/sync/core.extension.yml
@@ -34,6 +34,7 @@ module:
   options: 0
   page_cache: 0
   path: 0
+  responsive_image: 0
   search_api: 0
   search_api_db: 0
   simplei: 0

--- a/drupal/sync/image.style.space_image_full.yml
+++ b/drupal/sync/image.style.space_image_full.yml
@@ -1,0 +1,14 @@
+uuid: 84c08235-272a-4a3d-9fd8-5909b75087f1
+langcode: fi
+status: true
+dependencies: {  }
+name: space_image_full
+label: 'Space Image Full'
+effects:
+  5f9c7e67-80b8-4ef8-a435-017324772a1d:
+    uuid: 5f9c7e67-80b8-4ef8-a435-017324772a1d
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 1280
+      height: 852

--- a/drupal/sync/image.style.space_image_half.yml
+++ b/drupal/sync/image.style.space_image_half.yml
@@ -1,0 +1,14 @@
+uuid: 1f3c7e63-c387-4c6e-8754-89f5307b7738
+langcode: fi
+status: true
+dependencies: {  }
+name: space_image_half
+label: 'Space Image Half'
+effects:
+  fcf9a57b-5801-4603-b4f4-2c82079936bc:
+    uuid: fcf9a57b-5801-4603-b4f4-2c82079936bc
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 640
+      height: 426

--- a/drupal/sync/image.style.space_image_quarter.yml
+++ b/drupal/sync/image.style.space_image_quarter.yml
@@ -1,0 +1,7 @@
+uuid: 74e2babe-27b0-4c00-8d78-917c86e9b68e
+langcode: fi
+status: true
+dependencies: {  }
+name: space_image_quarter
+label: 'Space Image Quarter'
+effects: {  }

--- a/drupal/sync/responsive_image.styles.space_image.yml
+++ b/drupal/sync/responsive_image.styles.space_image.yml
@@ -1,0 +1,23 @@
+uuid: 1e4543e4-7fdc-4eb0-b994-ab63891cb0d6
+langcode: fi
+status: true
+dependencies:
+  config:
+    - image.style.space_image_full
+    - image.style.space_image_half
+    - image.style.space_image_quarter
+id: space_image
+label: 'Space Image'
+image_style_mappings:
+  -
+    breakpoint_id: responsive_image.viewport_sizing
+    multiplier: 1x
+    image_mapping_type: sizes
+    image_mapping:
+      sizes: '(min-width: 1280px) 640px, (min-width: 800px) 480px, 220px'
+      sizes_image_styles:
+        - space_image_full
+        - space_image_half
+        - space_image_quarter
+breakpoint_group: responsive_image
+fallback_image_style: space_image_quarter

--- a/drupal/sync/system.image.gd.yml
+++ b/drupal/sync/system.image.gd.yml
@@ -1,3 +1,3 @@
-jpeg_quality: 75
+jpeg_quality: 50
 _core:
   default_config_hash: eNXaHfkJJUThHeF0nvkoXyPLRrKYGxgHRjORvT4F5rQ


### PR DESCRIPTION
Responsive images for spaces. Space cards and space page use sensible image styles. They are responsive too with three different image sizes depending on the viewport (browser decides automatically).

To test: drush cim -y. Space images should depend on your browser window's size. Chrome's inspector should tell you the current image src being used.