### PR TITLE
HT-95: Only accept non empty values for field_capacity in Optime inte…

### DIFF
--- a/drupal/web/modules/custom/migrate_optime_json/config/install/migrate_plus.migration.optime_integration.yml
+++ b/drupal/web/modules/custom/migrate_optime_json/config/install/migrate_plus.migration.optime_integration.yml
@@ -153,7 +153,11 @@ process:
   field_optime_id: optime_id
   field_optime_index: optime_index
   field_building_id: building_id
-  field_capacity: capacity
+  field_capacity:
+    -
+      plugin: callback
+      callable: migrate_optime_json_get_capacity
+      source: capacity
   #field_last_changed_in_optime: last_changed_in_optime
   field_last_changed_in_optime:
   # Convert int to string, otherwise substr fails.

--- a/drupal/web/modules/custom/migrate_optime_json/migrate_optime_json.module
+++ b/drupal/web/modules/custom/migrate_optime_json/migrate_optime_json.module
@@ -13,6 +13,10 @@ use Drupal\Core\Url;
 use Drupal\Core\Site\Settings;
 use Drupal\redirect\Entity\Redirect;
 
+function migrate_optime_json_get_capacity($value = ""){
+  return !empty($value) ? $value : FALSE;
+}
+
 /** Simple migrate callbacks for filtering an address out of fields from a source
  *  which might contain a building name + address separated by a comma, or just the address.
  *    "buildingDescription": "Athena, Siltavuorenpenger 3 A"


### PR DESCRIPTION
Fixed practical issue in integration where field_capacity would accept 0 as value when in Optime that means that the capacity is "unknown" and should be left empty in the frontend.