### PR TITLE
After import operation delete unused Equipment taxonomy terms

### DIFF
--- a/drupal/web/modules/custom/migrate_optime_json/migrate_optime_json.services.yml
+++ b/drupal/web/modules/custom/migrate_optime_json/migrate_optime_json.services.yml
@@ -1,6 +1,10 @@
 services:
   migrate_optime_json.event_subscriber:
     class: Drupal\migrate_optime_json\EventSubscriber\MigrateOptimeJsonSubscriber
-    arguments: ['@current_user']
+    arguments: ['@entity_type.manager', '@logger.channel.migrate_optime_json']
     tags:
       - { name: event_subscriber }
+
+  logger.channel.migrate_optime_json:
+    parent: logger.channel_base
+    arguments: ['migrate_optime_json']


### PR DESCRIPTION
This PR provides "automatic" way to delete unused Equipment taxonomy terms after importing updates from Optime.

This PR relates to issue where changing equipment name in Optime leads to situation where equipment name is shown both with new and old name in the list of equipments on the search block.