### PR TITLE
HYTV-162: patched ds_chains to fix translation issue

### DIFF
--- a/drupal/composer.json
+++ b/drupal/composer.json
@@ -101,6 +101,9 @@
             "drupal/core": {
                 "Referenced entity rendered in wrong language when parent entity does not have translation enabled - #2859202": "https://www.drupal.org/files/issues/2021-11-26/2859202-35.patch",
                 "False recursive rendering errors - #2940605": "https://www.drupal.org/files/issues/2021-09-10/2940605_56.patch"
+            },
+            "drupal/ds_chains": {
+                "The chained entity is not loaded in the hosts entity language - #3295444": "https://www.drupal.org/files/issues/2022-07-12/load-the-chained-entity-translation-if-available.patch"
             }
         }
     },


### PR DESCRIPTION
Ticket: [HYTV-162](https://wunder.atlassian.net/browse/HYTV-162)

Translation issue with display suite chained fields. The Finnish translation is always shown instead of the active language.

Changes:
- Added a patch which checks if the chained field has a translation.

How to test:
- check that the "contact details" section shows translated version of the taxonomy term:
 EN: https://opetustila-test.it.helsinki.fi/en/node/288
 FI: https://opetustila-test.it.helsinki.fi/fi/node/288
 - compare to master where it the setup is the same (Building "Fabianinkatu 24" has 1 contact details value set "[A-rakennuksen vahtimestari](https://opetustila-test.it.helsinki.fi/fi/taxonomy/term/98)" and it's translated to "[Building A Lobby Services](https://opetustila-test.it.helsinki.fi/en/taxonomy/term/98)" and see that it only shows the Finnish one.
  EN: https://opetustila-staging.it.helsinki.fi/en/node/288
  FI: https://opetustila-staging.it.helsinki.fi/fi/node/288
  
Most terms aren't translated in the test env, so that's why looking at other ones it will show the only Finnish.