### PR TITLE
HYTV-170: Removed '-' from tokenizer ignored characters

### DIFF
--- a/drupal/sync/search_api.index.spaces_search.yml
+++ b/drupal/sync/search_api.index.spaces_search.yml
@@ -374,9 +374,10 @@ processor_settings:
     weights:
       preprocess_query: -49
   entity_status: {  }
+  entity_type: {  }
   hierarchy:
     weights:
-      preprocess_index: -42
+      preprocess_index: -45
     fields:
       field_campus: taxonomy_term-parent
   highlight:
@@ -385,6 +386,7 @@ processor_settings:
     prefix: '<strong>'
     suffix: '</strong>'
     excerpt: true
+    excerpt_always: false
     excerpt_length: 128
     exclude_fields: {  }
     highlight: always
@@ -441,6 +443,7 @@ processor_settings:
       - rendered_item
       - title
     spaces: ''
+    ignored: ._
     overlap_cjk: 1
     minimum_word_size: '3'
   transliteration:
@@ -477,7 +480,7 @@ processor_settings:
       - vid
   type_boost:
     weights:
-      preprocess_index: -43
+      preprocess_index: -45
     boosts:
       'entity:node':
         datasource_boost: !!float 1
@@ -499,4 +502,5 @@ tracker_settings:
 options:
   cron_limit: 50
   index_directly: true
+  track_changes_in_references: true
 server: opetustilat_drupal


### PR DESCRIPTION
Ticket: https://wunder.atlassian.net/browse/HYTV-170

When Global search index is re-indexed, it produces the following warning:

` [warning] An overlong word (more than 50 characters) was encountered while indexing: namedschainsnodespacefieldcampusfieldreservationinstructions.<br />Since database search servers currently cannot index words of more than 50 characters, the word was truncated for indexing. If this should not be a single word, please make sure the "Tokenizer" processor is enabled and configured correctly for index Global spaces search.`

Changes:
-  Removed the "-" character from the tokenizer "ignore characters" filter;

After changes:
```
>  [notice] Successfully indexed 50 items on Global spaces search.
>  [notice] Successfully indexed 100 items on Global spaces search.
>  [notice] Successfully indexed 150 items on Global spaces search.
>  [notice] Successfully indexed 200 items on Global spaces search.
>  [notice] Successfully indexed 250 items on Global spaces search.
>  [notice] Successfully indexed 300 items on Global spaces search.
>  [notice] Successfully indexed 350 items on Global spaces search.
>  [notice] Successfully indexed 400 items on Global spaces search.
>  [notice] Successfully indexed 450 items on Global spaces search.
>  [notice] Successfully indexed 500 items on Global spaces search.
>  [notice] Successfully indexed 550 items on Global spaces search.
>  [notice] Successfully indexed 600 items on Global spaces search.
>  [notice] Successfully indexed 650 items on Global spaces search.
>  [notice] Successfully indexed 700 items on Global spaces search.
>  [notice] Successfully indexed 750 items on Global spaces search.
>  [notice] Successfully indexed 800 items on Global spaces search.
>  [notice] Successfully indexed 850 items on Global spaces search.
>  [notice] Successfully indexed 900 items on Global spaces search.
>  [notice] Successfully indexed 950 items on Global spaces search.
>  [notice] Successfully indexed 1000 items on Global spaces search.
>  [notice] Successfully indexed 1050 items on Global spaces search.
>  [notice] Successfully indexed 1100 items on Global spaces search.
>  [notice] Successfully indexed 1136 items on Global spaces search.
>  [notice] Message: Successfully indexed 868 items.
>
>  [notice] Message: Successfully indexed 1136 items.
```

How to test:
- Compare search ( **What kind of facility do you need?** ) results between [testing](https://opetustila-test.it.helsinki.fi/en) and [production](https://tilavaraus.helsinki.fi/en/) environment. Shouldn't be any noticeable differences.

